### PR TITLE
Remove babel-polyfill

### DIFF
--- a/lib/MessageBox.js
+++ b/lib/MessageBox.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import Handlebars from 'handlebars';
 import deepExtend from 'deep-extend';
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "test:watch": "npm test -- --watch"
   },
   "dependencies": {
-    "babel-polyfill": "^6.9.1",
     "deep-extend": "^0.4.1",
     "handlebars": "^4.0.5"
   },


### PR DESCRIPTION
It's the job of the application to include a polyfill, not of a library.